### PR TITLE
issue 4002: pravega segmentstore could not obtain service endpoint in…

### DIFF
--- a/docker/pravega/scripts/init_kubernetes.sh
+++ b/docker/pravega/scripts/init_kubernetes.sh
@@ -55,6 +55,9 @@ init_kubernetes() {
                 echo "Trying to obtain LoadBalancer external endpoint..."
                 sleep 10
                 export PUBLISHED_ADDRESS=$( k8 "${ns}" "services" "${podname}" ".status.loadBalancer.ingress[0].ip" )
+                if [ -z "${PUBLISHED_ADDRESS}" ]; then
+                    export PUBLISHED_ADDRESS=$( k8 "${ns}" "services" "${podname}" ".status.loadBalancer.ingress[0].hostname" )
+                fi
                 export PUBLISHED_PORT=$( k8 "${ns}" "services" "${podname}" ".spec.ports[].port" )
             done
         elif [ "${service_type}" == "NodePort" ]; then


### PR DESCRIPTION
… aws environment

**Change log description**  
(2-3 concise points about the changes in this PR. When committing this PR, the committer is expected to copy the content of this section to the merge description box)

**Purpose of the change**  
Fixes #4002

**What the code does**  
script gets the hostnname from the status block of the loadbalancer service if ip is not found.

**How to verify it**  
k edit statefulset nautilus-pravega-segmentstore -n nautilus-pravega (change pull policy to Always)
kubectl patch statefulset nautilus-pravega-segmentstore -n nautilus-pravega --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"<repo>/nautilus-pravega:0.5.0-2291.3ccff63-0.9.0-025.14733bb-issue-4002"}]' 
k delete pod nautilus-pravega-segmentstore-0 -n nautilus-pravega
see segmentstore logs move past the following repeated messages and intialize, 
Trying to obtain LoadBalancer external endpoint...
and see all 3 segment stores are initialized
